### PR TITLE
replace `sklearn` with `scikit-learn` in `Part 3 - Time Series Forecasting.ipynb`

### DIFF
--- a/run-pipelines-on-data-science-pipelines/Part 3 - Time Series Forecasting.ipynb
+++ b/run-pipelines-on-data-science-pipelines/Part 3 - Time Series Forecasting.ipynb
@@ -52,7 +52,7 @@
    "outputs": [],
    "source": [
     "!pip3 install statsmodels\n",
-    "!pip3 install sklearn\n",
+    "!pip3 install scikit-learn\n",
     "!pip3 install matplotlib"
    ]
   },


### PR DESCRIPTION
```
Collecting sklearn
  Downloading sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 24.2 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
error: metadata-generation-failed

× Encountered error while generating package metadata. ╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```